### PR TITLE
js: Fix global variable, use strict mode

### DIFF
--- a/js/check_title.js
+++ b/js/check_title.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function check_original_title() {
 	var title_div = document.getElementsByClassName("title")[0];
 	var title_image = title_div.getElementsByTagName('img')[0];

--- a/js/duration.js
+++ b/js/duration.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function calc_duration(){
 	var duration_divs = document.querySelectorAll(".jsCalcDuration");
 	for (let i = 0; i < duration_divs.length; i++) {

--- a/js/fill_empty.js
+++ b/js/fill_empty.js
@@ -1,7 +1,9 @@
+'use strict';
+
 function fill_empty_listings(){
 	var listing_divs = document.getElementsByClassName("listing");
 	for(var i = 0; i < listing_divs.length; i++) {
-		listing_div = listing_divs[i];
+		var listing_div = listing_divs[i];
 		var text = [].reduce.call(listing_div.childNodes, function(a, b) { return a + (b.nodeType === 3 ? b.textContent : ''); }, '');
 		var clean_text = text.replace(/\s/g,'');
 		if (clean_text === "") {

--- a/js/filter.js
+++ b/js/filter.js
@@ -1,16 +1,17 @@
-function filter() {
-	var input, filter, ul, li, a, i, txtValue;
-	input = document.getElementById('filter_search');
-	filter = input.value.toLowerCase();
-	ul = document.getElementsByClassName("media-container")[0];
-	li = ul.getElementsByTagName('li');
+'use strict';
 
-	for (i = 0; i < li.length; i++) {
-		a = li[i].getElementsByTagName("a")[0];
-		txtValue = a.textContent || a.innerText;
-		filter_values = filter.split(" ");
+function filter() {
+	var input = document.getElementById('filter_search');
+	var filter = input.value.toLowerCase();
+	var ul = document.getElementsByClassName("media-container")[0];
+	var li = ul.getElementsByTagName('li');
+
+	for (var i = 0; i < li.length; i++) {
+		var a = li[i].getElementsByTagName("a")[0];
+		var txtValue = a.textContent || a.innerText;
+		var filter_values = filter.split(" ");
 		for (var j = filter_values.length - 1; j >= 0; j--) {
-			filter_word = filter_values[j];
+			var filter_word = filter_values[j];
 			if (txtValue.toLowerCase().indexOf(filter_word) > -1) {
 				li[i].style.display = "";
 			} else {

--- a/js/play_button.js
+++ b/js/play_button.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function media_available(){
 	var playMediaLinks = document.querySelectorAll(".play-media");
 	for (let i = 0; i < playMediaLinks.length; i++) {

--- a/js/trailer.js
+++ b/js/trailer.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function create_trailer_iframe() {
 	var videos = document.getElementsByClassName("trailer");
 	for (var i = 0; i < videos.length; i++) {

--- a/metadata.xml
+++ b/metadata.xml
@@ -2,10 +2,13 @@
 <metadata>
 	<name>Hidaya Theme</name>
 	<identifier>hidaya</identifier>
+	<website>https://github.com/Stunkymonkey/hidaya</website>
 	<description>dark theme with search functionality</description>
-	<description lang="de">dunkles Thema mit Suchfunktionalität</description>
+	<description lang="de">Dunkles Theme mit Suchfunktionalität</description>
 	<author>Friedrich Weise, Felix Bühler</author>
 	<version>1.0</version>
+	<mediaelch-min>2.6.7</mediaelch-min>
+	<engine>simple</engine>
 	<supports>
 		<section>movies</section>
 		<section>tvshows</section>


### PR DESCRIPTION
'use strict' should always be used. It is JavaScript's strict mode.
`listing_div` was a global variable, likely by accident.

------

I'd like to get these changes into the next hidaya version if possible. :-)
Then I'll add it to MediaElch's meta repository.

Note: You could also use `const`/`let` instead of `var`. After all you're using CSS  functions that are only supported by modern browsers so you could use modern JavaScript as well. ;)